### PR TITLE
Support running from within renv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ License: MIT + file LICENSE
 URL: https://github.com/cynkra/cynkrathis
 BugReports: https://github.com/cynkra/cynkrathis/issues
 Imports:
+    callr,
     checkmate,
     cli,
     gh,

--- a/R/renv.R
+++ b/R/renv.R
@@ -88,12 +88,6 @@ init_renv <- function(snapshot_date = NULL,
   cli::cli_alert_info("Scaffolding with repos = {.url {repos}}") # nolint
   renv::scaffold(project = ".", repos = repos)
 
-  # Load the packages now, we're nuking .libPaths()
-  rstudioapi::restartSession
-  callr::r
-
-  withr::local_libpaths()
-
   # FIXME: This is necessary, because scaffold() doesn't seem to install
   # a usable renv. Investigate.
   cli::cli_alert_info("Starting R session to bootstrap {.package renv}") # nolint

--- a/R/renv.R
+++ b/R/renv.R
@@ -102,24 +102,35 @@ init_renv <- function(snapshot_date = NULL,
   ))
 
   cli::cli_alert_info("Finalizing initialization of renv") # nolint
-  callr::r(finish_init_renv, show = TRUE, args = list(
+  callr::r_vanilla(user_profile = FALSE, show = TRUE, finish_init_renv, args = list(
     exclude = exclude,
     convenience_pkgs = convenience_pkgs,
     renv_latest = renv_latest
   ))
 
   cli::cli_alert_info("Restoring all packages") # nolint
-  callr::r(function() renv::restore(clean = TRUE), show = TRUE)
-
-  cli::cli_alert_info("Restoring all packages again") # nolint
-  callr::r(function() renv::restore(), show = TRUE)
+  callr::r_vanilla(user_profile = FALSE, show = TRUE, function() {
+    source(".Rprofile")
+    renv::restore(clean = TRUE)
+  })
 
   if (Sys.getenv("RSTUDIO") == 1) {
     rstudioapi::restartSession()
   }
 }
 
+# Called in a fresh vanilla R session
+install_github_renv <- function(renv_latest) {
+  source(".Rprofile")
+
+  renv::install(paste0("rstudio/renv@", renv_latest))
+  renv::snapshot()
+}
+
+# Called in a fresh vanilla R session
 finish_init_renv <- function(exclude, convenience_pkgs, renv_latest) {
+  source(".Rprofile")
+
   # print projects renv path: Problem: The library needs to be empty, otherwise
   # the wrong versions are stored in it (from previous renv inits)
   # renv_dir <- .libPaths()[1]

--- a/R/renv.R
+++ b/R/renv.R
@@ -161,7 +161,7 @@ finish_init_renv <- function(exclude, convenience_pkgs, renv_latest) {
 local_remove_renv_envvars <- function(.local_envir = parent.frame()) {
   bad_env <-
     c(
-      grep("^RENV_", names(Sys.getenv()), value = TRUE),
+      "RENV_PROJECT",
       "R_LIBS_USER"
     )
   new <- rlang::set_names(rlang::rep_along(bad_env, NA_character_), bad_env)

--- a/R/renv.R
+++ b/R/renv.R
@@ -1,6 +1,7 @@
 #' Initialize {renv} infrastructure (cynkra way)
 #'
-#' @description Initializes {renv} setup by setting a predefined RStudio Package
+#' @description
+#' Initializes {renv} setup by setting a predefined RStudio Package
 #' Manager (RSPM) snapshot.
 #' Custom RSPM Snapshots can be configured via `snapshot_date`.
 #'
@@ -24,10 +25,14 @@
 #'
 #' @details
 #' During the process, the latest CRAN version of {renv} will be installed,
-#' regardless of the chose snapshot ID.
+#' regardless of the chosen snapshot ID.
 #'
 #' The heuristic for setting the correct RSPM binary repo currently only supports
 #' Windows, macOS and Ubuntu 20.04.
+#'
+#' The initialization mostly runs in clean vanilla sessions started with
+#' [callr::r_vanilla()].
+#'
 #' @importFrom utils tail available.packages
 #' @importFrom rstudioapi restartSession
 #' @examples

--- a/R/renv.R
+++ b/R/renv.R
@@ -97,6 +97,7 @@ init_renv <- function(snapshot_date = NULL,
   # FIXME: This is necessary, because scaffold() doesn't seem to install
   # a usable renv. Investigate.
   cli::cli_alert_info("Starting R session to bootstrap {.package renv}") # nolint
+  # https://github.com/r-lib/callr/issues/194
   callr::r_vanilla(user_profile = FALSE, show = TRUE, install_github_renv, args = list(
     renv_latest = renv_latest
   ))

--- a/R/renv.R
+++ b/R/renv.R
@@ -88,8 +88,7 @@ init_renv <- function(snapshot_date = NULL,
   cli::cli_alert_info("Scaffolding with repos = {.url {repos}}") # nolint
   renv::scaffold(project = ".", repos = repos)
 
-  # FIXME: This is necessary, because scaffold() doesn't seem to install
-  # a usable renv. Investigate.
+  # Install the correct renv version in a new session
   cli::cli_alert_info("Starting R session to bootstrap {.package renv}") # nolint
   # https://github.com/r-lib/callr/issues/194
   callr::r_vanilla(user_profile = FALSE, show = TRUE, install_github_renv, args = list(

--- a/R/renv.R
+++ b/R/renv.R
@@ -103,12 +103,6 @@ init_renv <- function(snapshot_date = NULL,
     renv_latest = renv_latest
   ))
 
-  cli::cli_alert_info("Restoring all packages") # nolint
-  callr::r_vanilla(user_profile = FALSE, show = TRUE, function() {
-    source(".Rprofile")
-    renv::restore(clean = TRUE)
-  })
-
   if (Sys.getenv("RSTUDIO") == 1) {
     rstudioapi::restartSession()
   }

--- a/R/renv.R
+++ b/R/renv.R
@@ -79,6 +79,8 @@ init_renv <- function(snapshot_date = NULL,
     )
   }
 
+  local_remove_renv_envvars()
+
   renv::scaffold(project = ".", repos = repos)
 
   # set repos for current session
@@ -148,6 +150,13 @@ init_renv <- function(snapshot_date = NULL,
     rstudioapi::restartSession()
   }
   renv::restore()
+}
+
+local_remove_renv_envvars <- function(.local_envir = parent.frame()) {
+  bad_env <- grep("^RENV_", names(Sys.getenv()), value = TRUE)
+  new <- rlang::set_names(rlang::rep_along(bad_env, NA_character_), bad_env)
+
+  withr::local_envvar(new, .local_envir = .local_envir)
 }
 
 #' Switch between R versions in renv projects

--- a/R/renv.R
+++ b/R/renv.R
@@ -79,6 +79,7 @@ init_renv <- function(snapshot_date = NULL,
     )
   }
 
+  # Necessary if we're already in an renv session
   local_remove_renv_envvars()
 
   # always install latest renv version

--- a/R/renv.R
+++ b/R/renv.R
@@ -161,13 +161,12 @@ finish_init_renv <- function(exclude, convenience_pkgs, renv_latest) {
     deps <- setdiff(deps, exclude)
   }
 
+  deps <- setdiff(deps, "renv")
+
   renv::install(deps)
 
   message("Snapshotting installed packages.")
   renv::snapshot(prompt = FALSE)
-
-  # Need to record manually again
-  renv::record(project = ".", paste0("renv@", renv_latest))
 
   renv::rehash(prompt = FALSE)
 }

--- a/R/renv.R
+++ b/R/renv.R
@@ -149,6 +149,7 @@ finish_init_renv <- function(exclude, convenience_pkgs, renv_latest) {
     deps <- setdiff(deps, exclude)
   }
 
+  # Avoid reinstalling renv
   deps <- setdiff(deps, "renv")
 
   renv::install(deps)

--- a/R/renv.R
+++ b/R/renv.R
@@ -85,11 +85,8 @@ init_renv <- function(snapshot_date = NULL,
   av_pkgs <- utils::available.packages(repos = "https://packagemanager.rstudio.com/cran/latest") # nolint
   renv_latest <- av_pkgs[rownames(av_pkgs) == "renv", "Version"]
 
-  cli::cli_alert_info("Scaffolding with {.pkg renv} {.version {renv_latest}}") # nolint
-  renv::scaffold(project = ".", version = renv_latest, repos = repos)
-
-  # Need to record manually
-  renv::record(project = ".", paste0("renv@", renv_latest))
+  cli::cli_alert_info("Scaffolding with repos = {.url {repos}}") # nolint
+  renv::scaffold(project = ".", repos = repos)
 
   # Load the packages now, we're nuking .libPaths()
   rstudioapi::restartSession
@@ -100,7 +97,9 @@ init_renv <- function(snapshot_date = NULL,
   # FIXME: This is necessary, because scaffold() doesn't seem to install
   # a usable renv. Investigate.
   cli::cli_alert_info("Starting R session to bootstrap {.package renv}") # nolint
-  callr::r(function() packageVersion("renv"), show = TRUE)
+  callr::r_vanilla(user_profile = FALSE, show = TRUE, install_github_renv, args = list(
+    renv_latest = renv_latest
+  ))
 
   cli::cli_alert_info("Finalizing initialization of renv") # nolint
   callr::r(finish_init_renv, show = TRUE, args = list(

--- a/man/init_renv.Rd
+++ b/man/init_renv.Rd
@@ -35,10 +35,13 @@ Custom RSPM Snapshots can be configured via \code{snapshot_date}.
 }
 \details{
 During the process, the latest CRAN version of {renv} will be installed,
-regardless of the chose snapshot ID.
+regardless of the chosen snapshot ID.
 
 The heuristic for setting the correct RSPM binary repo currently only supports
 Windows, macOS and Ubuntu 20.04.
+
+The initialization mostly runs in clean vanilla sessions started with
+\code{\link[callr:r_vanilla]{callr::r_vanilla()}}.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
I'm using a global renv in `~`. This makes initialization of other renv projects difficult.

Achieved by:

1. `scaffold()` in the main session
1. renv setup in a vanilla session
1. dependency discovery + snapshotting in another session

Also using `install(deps)` in favor of `install()` .

I tried various combinations, this looks like the minimum number of steps necessary.