### PR TITLE
Optimize `renv_downgrade()`

### DIFF
--- a/R/renv.R
+++ b/R/renv.R
@@ -419,15 +419,13 @@ renv_downgrade <- function() {
   # also include "recommended" pkgs as otherwise deployments to RSC may fail
   # e.g. if a recommended package version does not align with the RSPM
   # snapshot on RSC
-  pkgs_to_install <- setdiff(installed_pkgs, c(
-    non_avail,
-    names(which(available.packages(
+  pkgs_to_install <- setdiff(
+    c(installed_pkgs, names(which(available.packages(
       repos =
         c(CRAN = "https://cran.r-project.org")
-    )[, "Priority"] == "recommended", ))
-  ))
-
-
+    )[, "Priority"] == "recommended", ))),
+    non_avail
+  )
 
   snapshot_date <- stringr::str_extract(
     readLines("renv.lock", n = 7)[7],

--- a/R/renv.R
+++ b/R/renv.R
@@ -415,7 +415,7 @@ renv_downgrade <- function() {
   # check only available packages on 'repos' set to avoid download failures
   # for non-avail pkgs (e.g. GitHub packages)
   avail_pkgs <- available.packages()[, "Package"]
-  non_avail <- setdiff(installed_pkgs, avail)
+  non_avail <- setdiff(installed_pkgs, avail_pkgs)
   pkgs_to_install <- setdiff(installed_pkgs, non_avail)
 
   snapshot_date <- stringr::str_extract(

--- a/R/renv.R
+++ b/R/renv.R
@@ -416,7 +416,18 @@ renv_downgrade <- function() {
   # for non-avail pkgs (e.g. GitHub packages)
   avail_pkgs <- available.packages()[, "Package"]
   non_avail <- setdiff(installed_pkgs, avail_pkgs)
-  pkgs_to_install <- setdiff(installed_pkgs, non_avail)
+  # also include "recommended" pkgs as otherwise deployments to RSC may fail
+  # e.g. if a recommended package version does not align with the RSPM
+  # snapshot on RSC
+  pkgs_to_install <- setdiff(installed_pkgs, c(
+    non_avail,
+    names(which(available.packages(
+      repos =
+        c(CRAN = "https://cran.r-project.org")
+    )[, "Priority"] == "recommended", ))
+  ))
+
+
 
   snapshot_date <- stringr::str_extract(
     readLines("renv.lock", n = 7)[7],

--- a/R/renv.R
+++ b/R/renv.R
@@ -412,6 +412,12 @@ renv_downgrade <- function() {
     lib.loc = .libPaths()[1]
   )[, "Package"])
 
+  # check only available packages on 'repos' set to avoid download failures
+  # for non-avail pkgs (e.g. GitHub packages)
+  avail_pkgs <- available.packages()[, "Package"]
+  non_avail <- setdiff(installed_pkgs, avail)
+  pkgs_to_install <- setdiff(installed_pkgs, non_avail)
+
   snapshot_date <- stringr::str_extract(
     readLines("renv.lock", n = 7)[7],
     "[0-9]{4}-[0-9]{2}-[0-9]{2}"
@@ -419,7 +425,7 @@ renv_downgrade <- function() {
   cli::cli_alert_info("Reinstalling all packages using RSPM snapshot
     {.field {snapshot_date}}.", wrap = TRUE)
 
-  renv::install(installed_pkgs)
+  renv::install(pkgs_to_install)
 
   cli::cli_alert_success("Successfully rebased all packages to RSPM snapshot
     {.field {snapshot_date}}.", wrap = TRUE)


### PR DESCRIPTION
I just had a use case for `renv_downgrade()` and realized that we always need to include the "recommended" packages as well.
Otherwise, RSC will fail when deploying as it tries to install a "recommended" package with a version which is not available in the linked RSPM snapshot.

